### PR TITLE
update mocha-webpack to fix "0 passing"

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "mocha": "^3.0.2",
-    "mocha-webpack": "^0.7.0",
+    "mocha-webpack": "^1.0.0-beta.1",
     "raw-loader": "^0.5.1",
     "source-map-support": "0.4.3",
     "ts-loader": "^0.9.1",


### PR DESCRIPTION
I just published `1.0.0-beta.1` of mocha-webpack which fixes the "0 passing" issue (zinserjan/mocha-webpack#48).

You can install it with:

```bash
$ npm install --save-dev mocha-webpack@next
``` 

Thanks for this sample repo. It was very useful :)